### PR TITLE
Add lowGran reporting mapping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1639440'
+ValidationKey: '1661648'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reportbrick: Reporting package for BRICK'
-version: 0.8.1
-date-released: '2025-06-01'
+version: 0.8.2
+date-released: '2025-06-25'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
-Version: 0.8.1
-Date: 2025-06-01
+Version: 0.8.2
+Date: 2025-06-25
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/reportAgg.R
+++ b/R/reportAgg.R
@@ -109,9 +109,17 @@ reportAgg <- function(x,
     out <- do.call(mbind, apply(rprtCombinations, 1, function(comb) {
       # replace dimension tags to get final variable name
       outName <- name
+
       for (r in names(comb)) {
+        label <- brickSets[[r]][["elements"]][[comb[[r]]]]
+        if (label == "") {
+          if (isFALSE(silent)) {
+            message("No label given to item '", comb, "'. Respective variable is skipped.")
+          }
+          return(NULL)
+        }
         outName <- sub(.tag(r),
-                       brickSets[[r]][["elements"]][[comb[[r]]]],
+                       label,
                        outName, fixed = TRUE)
       }
 
@@ -201,8 +209,8 @@ reportAgg <- function(x,
 #'
 #' @param x MagPIE object, BRICK object
 #' @param agg named vector of dimensions to aggregate.
-#' @returns aggregated MagPIE objects without sub dimensions in dim 3
 #' @param silent logical, suppress warnings and printing of dimension mapping
+#' @returns aggregated MagPIE objects without sub dimensions in dim 3
 #'
 #' @importFrom magclass dimSums mselect
 

--- a/R/reportRenovation.R
+++ b/R/reportRenovation.R
@@ -8,14 +8,15 @@
 #'
 #' @author Ricarda Rosemann
 #'
-#' @importFrom magclass mbind setNames mselect collapseDim
+#' @importFrom magclass mbind setNames mselect collapseDim complete_magpie
 
 reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
 
   # READ -----------------------------------------------------------------------
 
   # renovation variable
-  v_renovation <- readGdxSymbol(gdx, "v_renovation")
+  v_renovation <- readGdxSymbol(gdx, "v_renovation") %>%
+    complete_magpie(fill = 0)
 
   # unit conversion: million m2 / yr-> billion m2 / yr
   v_renovation <- (v_renovation / 1000) %>%
@@ -40,12 +41,12 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
               silent = silent),
     reportAgg(v_renovation,
               "Renovation|Residential|Shell(bn m2/yr)", brickSets,
-              agg = c(bs = "all", hs = "all", bsr = "all", hsr = "all0", vin = "all",
+              agg = c(bs = "all", hs = "all", bsr = "all", hsr = "allr", vin = "all",
                       loc = "all", typ = "res", inc = "all"),
               silent = silent),
     reportAgg(v_renovation,
               "Renovation|Residential|Heating (bn m2/yr)", brickSets,
-              agg = c(bs = "all", hs = "all", bsr = "all0", hsr = "all", vin = "all",
+              agg = c(bs = "all", hs = "all", bsr = "allr", hsr = "all", vin = "all",
                       loc = "all", typ = "res", inc = "all"),
               silent = silent),
     reportAgg(v_renovation,
@@ -72,7 +73,7 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
     ## by final building shell ====
     reportAgg(v_renovation,
               "Renovation|Residential|Final|{bsr} (bn m2/yr)", brickSets,
-              agg = c(bs = "all", hs = "all", hsr = "all0", vin = "all", loc = "all", typ = "res", inc = "all"),
+              agg = c(bs = "all", hs = "all", hsr = "allr", vin = "all", loc = "all", typ = "res", inc = "all"),
               rprt = c(bsr = "all"),
               silent = silent),
 
@@ -80,7 +81,7 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
     ## by initial heating system ====
     reportAgg(v_renovation,
               "Renovation|Residential|Initial|{hs} (bn m2/yr)", brickSets,
-              agg = c(bs = "all", bsr = "all0", hsr = "all", vin = "all", loc = "all", typ = "res", inc = "all"),
+              agg = c(bs = "all", bsr = "allr", hsr = "all", vin = "all", loc = "all", typ = "res", inc = "all"),
               rprt = c(hs = "all"),
               silent = silent),
 
@@ -88,7 +89,7 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
     ## by building type + initial heating system ====
     reportAgg(v_renovation,
               "Renovation|Residential|{typ}|Initial|{hs} (bn m2/yr)", brickSets,
-              agg = c(bs = "all", bsr = "all0", hsr = "all", vin = "all", loc = "all", inc = "all"),
+              agg = c(bs = "all", bsr = "allr", hsr = "all", vin = "all", loc = "all", inc = "all"),
               rprt = c(hs = "all", typ = "res"),
               silent = silent),
 
@@ -96,35 +97,35 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
     ## by final heating system ====
     reportAgg(v_renovation,
               "Renovation|Residential|Final|{hsr} (bn m2/yr)", brickSets,
-              agg = c(bs = "all", hs = "all", bsr = "all0", vin = "all", loc = "all", typ = "res", inc = "all"),
-              rprt = c(hsr = "all0"),
+              agg = c(bs = "all", hs = "all", bsr = "allr", vin = "all", loc = "all", typ = "res", inc = "all"),
+              rprt = c(hsr = "allr"),
               silent = silent),
 
     ## only identical replacement of the building shell ====
     reportAgg(v_renovation,
               "Renovation|Residential|Shell|Identical replacement (bn m2/yr)", brickSets,
-              agg = c(bs.bsr = "identRepl", hs = "all", hsr = "all0", vin = "all", loc = "all",
+              agg = c(bs.bsr = "identRepl", hs = "all", hsr = "allr", vin = "all", loc = "all",
                       typ = "res", inc = "all"),
               silent = silent),
 
     ## only identical replacement of the heating system ====
     reportAgg(v_renovation,
               "Renovation|Residential|Heating|Identical replacement (bn m2/yr)", brickSets,
-              agg = c(bs = "all", hs.hsr = "identRepl", bsr = "all0", vin = "all", loc = "all",
+              agg = c(bs = "all", hs.hsr = "identRepl", bsr = "allr", vin = "all", loc = "all",
                       typ = "res", inc = "all"),
               silent = silent),
 
     ## only identical shell replacement by building shell ====
     reportAgg(v_renovation,
               "Renovation|Residential|Identical replacement|{bs.bsr} (bn m2/yr)", brickSets,
-              agg = c(hs = "all", hsr = "all0", vin = "all", loc = "all", typ = "res", inc = "all"),
+              agg = c(hs = "all", hsr = "allr", vin = "all", loc = "all", typ = "res", inc = "all"),
               rprt = c(bs.bsr = "identRepl"),
               silent = silent),
 
     ## only identical heating replacement by heating system ====
     reportAgg(v_renovation,
               "Renovation|Residential|Identical replacement|{hs.hsr} (bn m2/yr)", brickSets,
-              agg = c(bs = "all", bsr = "all0", vin = "all", loc = "all", typ = "res", inc = "all"),
+              agg = c(bs = "all", bsr = "allr", vin = "all", loc = "all", typ = "res", inc = "all"),
               rprt = c(hs.hsr = "identRepl"),
               silent = silent)
 
@@ -136,22 +137,21 @@ reportRenovation <- function(gdx, brickSets = NULL, silent = TRUE) {
 
     ## only changes of heating systems ====
     setNames(
-      out[, , "Renovation|Residential|Heating (bn m2/yr)"]
-      - out[, , "Renovation|Residential|Heating|Identical replacement (bn m2/yr)"],
+      out[, , "Renovation|Residential|Heating (bn m2/yr)", drop = TRUE]
+      - out[, , "Renovation|Residential|Heating|Identical replacement (bn m2/yr)", drop = TRUE],
       "Renovation|Residential|Change of heating system (bn m2/yr)"
     ),
 
     ## only changes of heating systems by heating system ====
     do.call(mbind, lapply(brickSets[["hsr"]][["subsets"]][["all"]], function(elemName) {
       elem <- brickSets[["hsr"]][["elements"]][[elemName]]
-      setNames(
-        out[, , paste0("Renovation|Residential|Final|", elem, " (bn m2/yr)")]
-        - out[, , paste0("Renovation|Residential|Identical replacement|", elem, " (bn m2/yr)")],
-        paste0("Renovation|Residential|Change of heating system|Final|", elem, " (bn m2/yr)")
-      )
-    })
-    )
+      renFinal <- paste0("Renovation|Residential|Final|", elem, " (bn m2/yr)")
+      renIdentRepl <- paste0("Renovation|Residential|Identical replacement|", elem, " (bn m2/yr)")
 
+      renChangeFinal <- paste0("Renovation|Residential|Change of heating system|Final|", elem, " (bn m2/yr)")
+      setNames(out[, , renFinal, drop = TRUE] - out[, , renIdentRepl, drop = TRUE],
+               renChangeFinal)
+    }))
   )
 
   return(out)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for BRICK
 
-R package **reportbrick**, version **0.8.1**
+R package **reportbrick**, version **0.8.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reportbrick)](https://cran.r-project.org/package=reportbrick) [![R build status](https://github.com/pik-piam/reportbrick/workflows/check/badge.svg)](https://github.com/pik-piam/reportbrick/actions) [![codecov](https://codecov.io/gh/pik-piam/reportbrick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reportbrick) [![r-universe](https://pik-piam.r-universe.dev/badges/reportbrick)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,15 +38,17 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **reportbrick** in publications use:
 
-Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK - Version 0.8.1."
+Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.8.2, <https://github.com/pik-piam/reportbrick>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {reportbrick: Reporting package for BRICK - Version 0.8.1},
+  title = {reportbrick: Reporting package for BRICK},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-06-01},
+  date = {2025-06-25},
   year = {2025},
+  url = {https://github.com/pik-piam/reportbrick},
+  note = {Version: 0.8.2},
 }
 ```

--- a/inst/extdata/sectoral/brickSets.yaml
+++ b/inst/extdata/sectoral/brickSets.yaml
@@ -10,7 +10,7 @@ bsr:
     "0": No change
   subsets:
     all: [low, med, high]
-    all0: [low, med, high, "0"]
+    allr: [low, med, high, "0"]
   child:
     bs:
       elements: [low, med, high]
@@ -31,7 +31,7 @@ hsr:
     "0": No change
   subsets:
     all: [biom, dihe, ehp1, reel, h2bo, gabo, libo, sobo]
-    all0: [biom, dihe, ehp1, reel, h2bo,  gabo, libo, sobo, "0"]
+    allr: [biom, dihe, ehp1, reel, h2bo,  gabo, libo, sobo, "0"]
     elec: [ehp1, reel]
   child:
     hs:

--- a/inst/extdata/sectoral/brickSets_ignoreShell_onlyRes.yaml
+++ b/inst/extdata/sectoral/brickSets_ignoreShell_onlyRes.yaml
@@ -7,7 +7,7 @@ bsr:
     "0": No change
   subsets:
     all: low
-    all0: [low, "0"]
+    allr: "0"
   child:
     bs:
       elements: low

--- a/inst/extdata/sectoral/brickSets_lowGran_ignoreShell.yaml
+++ b/inst/extdata/sectoral/brickSets_lowGran_ignoreShell.yaml
@@ -1,0 +1,69 @@
+---
+## Building shell ====
+# Only low for state and `0` for renovation
+bsr:
+  elements:
+    low: Low efficiency
+    "0": No change
+  subsets:
+    all: low
+    allr: "0"
+  child:
+    bs:
+      elements: low
+      subsets: all
+
+
+## Vintage ====
+# future 20 yr cohorts
+vin:
+  elements:
+    before1945: Before 1945
+    1945-1969: 1945 - 1969
+    1970-1979: 1970 - 1979
+    1980-1989: 1980 - 1989
+    1990-1999: 1990 - 1999
+    2000-2010: 2000 - 2010
+    2011-2020: 2011 - 2020
+    2021-2040: 2021 - 2040
+    2041-2060: 2041 - 2060
+    2061-2080: 2061 - 2080
+    2081-2100: 2081 - 2100
+    after2100: After 2100
+  subsets:
+    all: [before1945, 1945-1969, 1970-1979, 1980-1989, 1990-1999, 2000-2010,
+          2011-2020, 2021-2040, 2041-2060, 2061-2080, 2081-2100, after2100]
+    hist: [before1945, 1945-1969, 1970-1979, 1980-1989, 1990-1999, 2000-2010,
+           2011-2020]
+    future: [2021-2040, 2041-2060, 2061-2080, 2081-2100, after2100]
+
+
+## Location ====
+# no distinction
+loc:
+  elements:
+    all: ""
+
+
+## Building type ====
+# No residential subtypes
+typ:
+  elements:
+    Res: ""
+    Com: ""
+  subsets:
+    resCom: [Res, Com]
+    res: Res
+    com: Com
+
+
+## Renovation ====
+bs.bsr:
+  subsets:
+    identRepl: []
+
+# Only `0` for renovation
+bsr.hsr:
+  subsets:
+    all: [0.biom, 0.dihe, 0.ehp1, 0.reel, 0.h2bo, 0.gabo, 0.libo, 0.sobo]
+...


### PR DESCRIPTION
- I added a new reporting mapping for _lowGran_ with _ignoreShell_
  - I had to change `reportAgg` such that it will return `NULL` when one tries to report a variable where the label that should replace a tag in the variable name is empty. This was needed for the dimension `loc` that only has the elements `Res` and `Com` in the new mapping. Now we don't get any variables for residential subtypes because the `typ` element `Res` has an empty label.
- I changed the subset of target renovation elements to `allr`. This set is no longer necessarily the union of `all` and `"0"`. If the shell is ignored, `bsr` can only be `"0"`.
- I complete the renovation variable with zero to hold all combinations of dimension elements. Otherwise, forbidden renovations are not included and `reportAgg` will always return zero because of missing model variables.
- I had to add the argument `drop = TRUE` where masking is used to select variables that are then added or subtracted to calculate other variables. Otherwise, magclass will blow up the 3rd dimension. No idea why this worked before...