### PR TITLE
Handle sequential renovation in sankey plot 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1824570'
+ValidationKey: '1846117'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reportbrick: Reporting package for BRICK'
-version: 0.9.0
-date-released: '2025-07-04'
+version: 0.9.1
+date-released: '2025-07-18'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
-Version: 0.9.0
-Date: 2025-07-04
+Version: 0.9.1
+Date: 2025-07-18
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
   gamstransfer (>= 3.0.1),
   ggplot2,
   ggpubr,
+  ggsankey,
   kableExtra,
   knitr,
   madrat,
@@ -34,7 +35,6 @@ Imports:
   yaml
 Suggests:
   covr,
-  ggsankey,
   testthat
 Encoding: UTF-8
 RoxygenNote: 7.3.2

--- a/R/showSankey.R
+++ b/R/showSankey.R
@@ -39,10 +39,6 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
                        maxPeriodsInRow = NULL,
                        save = TRUE) {
 
-  if (isFALSE(requireNamespace("ggsankey", quietly = TRUE))) {
-    warning("Can't plot sankey. Install 'ggsankey' from GitHub.")
-    return(invisible(NULL))
-  }
 
   fill <- match.arg(fill)
 

--- a/R/showSankey.R
+++ b/R/showSankey.R
@@ -595,6 +595,8 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
 
   # READ DATA ------------------------------------------------------------------
 
+  m <- gamstransfer::Container$new(gdx)
+
   dt <- readGdxSymbol(gdx, "p_dt", asMagpie = FALSE) %>%
     select("ttot", dt = "value") %>%
     mutate(dtNext = lead(.data$dt))
@@ -603,7 +605,11 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
     Stock        = "v_stock",
     Construction = "v_construction",
     Demolition   = "v_demolition",
-    Renovation   = "v_renovation"
+    Renovation   = if (m$hasSymbols("v_renovationBS")) {
+      switch(fill, bs = "v_renovationBS", hs = "v_renovationHS")
+    } else {
+      "v_renovation"
+    }
   )
 
   data <- lapply(vars, function(v) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for BRICK
 
-R package **reportbrick**, version **0.9.0**
+R package **reportbrick**, version **0.9.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reportbrick)](https://cran.r-project.org/package=reportbrick) [![R build status](https://github.com/pik-piam/reportbrick/workflows/check/badge.svg)](https://github.com/pik-piam/reportbrick/actions) [![codecov](https://codecov.io/gh/pik-piam/reportbrick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reportbrick) [![r-universe](https://pik-piam.r-universe.dev/badges/reportbrick)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **reportbrick** in publications use:
 
-Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.9.0, <https://github.com/pik-piam/reportbrick>.
+Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.9.1, <https://github.com/pik-piam/reportbrick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reportbrick: Reporting package for BRICK},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-04},
+  date = {2025-07-18},
   year = {2025},
   url = {https://github.com/pik-piam/reportbrick},
-  note = {Version: 0.9.0},
+  note = {Version: 0.9.1},
 }
 ```


### PR DESCRIPTION
With this PR, sankey plots can also be created for runs with sequential renovation. If we decide to go with sequential renovation and drop the hierarchical choice, the case distinction here can be removed, too. It might not be super robust anyways, as you can get a symbol through the start.gdx even if it is not part of the model. You would have to read the config to be sure but for the intermediate time being, I hope this is fine.
Moreover, ggsankey is now treated as a dependency like any other as well as it is now available through the RSE server.