### PR TITLE
Bugfix: showSankey can now handle multiple regions and short time steps

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1846117'
+ValidationKey: '1867692'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reportbrick: Reporting package for BRICK'
-version: 0.9.1
-date-released: '2025-07-18'
+version: 0.9.2
+date-released: '2025-08-01'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
-Version: 0.9.1
-Date: 2025-07-18
+Version: 0.9.2
+Date: 2025-08-01
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/showSankey.R
+++ b/R/showSankey.R
@@ -476,7 +476,8 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
                                 next_node = .data$next_node,
                                 value = .data$value,
                                 shift = .data$shift),
-                            data) %>%
+                            data,
+                            width = 0) %>%
       suppressWarnings()
   }
 
@@ -635,7 +636,7 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
 
   # sum over vintages and stock subsets
   aggDim <- setdiff(
-    c("bs", "hs", "bsr", "hsr", "vin", "reg", "loc", "typ", "inc", "value"),
+    c("bs", "hs", "bsr", "hsr", "vin", "region", "loc", "typ", "inc", "value"),
     c(fill, paste0(fill, "r"))
   )
   data <- lapply(data, function(var) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for BRICK
 
-R package **reportbrick**, version **0.9.1**
+R package **reportbrick**, version **0.9.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reportbrick)](https://cran.r-project.org/package=reportbrick) [![R build status](https://github.com/pik-piam/reportbrick/workflows/check/badge.svg)](https://github.com/pik-piam/reportbrick/actions) [![codecov](https://codecov.io/gh/pik-piam/reportbrick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reportbrick) [![r-universe](https://pik-piam.r-universe.dev/badges/reportbrick)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **reportbrick** in publications use:
 
-Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.9.1, <https://github.com/pik-piam/reportbrick>.
+Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.9.2, <https://github.com/pik-piam/reportbrick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reportbrick: Reporting package for BRICK},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-18},
+  date = {2025-08-01},
   year = {2025},
   url = {https://github.com/pik-piam/reportbrick},
-  note = {Version: 0.9.1},
+  note = {Version: 0.9.2},
 }
 ```


### PR DESCRIPTION
Sankey plots didn't look nice for matching runs. Bars differentiated regions and for short time steps (here 1 yr), the alluvial bars were visible behind the bars printed above. I fixed both.

**before**
<img width="937" height="223" alt="grafik" src="https://github.com/user-attachments/assets/e4967c61-56f6-4cf7-9090-2c5d5eec54cd" />

**after**
<img width="940" height="221" alt="grafik" src="https://github.com/user-attachments/assets/2f1e68b7-fc6f-46a7-8ce6-f6daf418d9f9" />
