### PR TITLE
Adjust calibration reporting to sequential renovation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,10 +1,10 @@
-ValidationKey: '2236740'
+ValidationKey: '2440080'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
 AcceptedNotes: Namespaces in Imports field not imported from\:\n *.kableExtra. .knitr.
-  .piamPlotComparison. .purrr.
+  .piamPlotComparison.
 allowLinterWarnings: no
 enforceVersionUpdate: no
 AutocreateCITATION: yes

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2440080'
+ValidationKey: '2441760'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reportbrick: Reporting package for BRICK'
-version: 0.11.0
+version: 0.12.0
 date-released: '2025-09-03'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'reportbrick: Reporting package for BRICK'
 version: 0.12.0
-date-released: '2025-09-03'
+date-released: '2025-09-17'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
 Version: 0.12.0
-Date: 2025-09-03
+Date: 2025-09-17
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
-Version: 0.11.0
+Version: 0.12.0
 Date: 2025-09-03
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",

--- a/R/plotBRICKCalib.R
+++ b/R/plotBRICKCalib.R
@@ -8,7 +8,6 @@
 #' @param outName character, string added to the pdf file name and names of additionally saved plots
 #' @param scenNames character vector, scenario names for different paths.
 #'  Needs to be specified if \code{path} is unnamed and contains more than one element.
-#' @param savePlots logical, whether all plots should additionally be saved as png
 #'
 #' @author Ricarda Rosemann
 #'
@@ -17,8 +16,7 @@
 #' @export
 
 plotBRICKCalib <- function(path = ".", cal = "BRICK_calibration_report.csv",
-                           outName = "", scenNames = NULL,
-                           savePlots = FALSE) {
+                           outName = "", scenNames = NULL) {
 
   # Extract the scenario name from the output directory
   scenario <- sub("_\\d{4}-\\d{2}-\\d{2}_\\d{2}\\.\\d{2}\\.\\d{2}", "", basename(path))
@@ -43,9 +41,7 @@ plotBRICKCalib <- function(path = ".", cal = "BRICK_calibration_report.csv",
     path = normalizePath(path),
     cal = cal,
     docTitle = paste("BRICK Calibration Report", paste(scenario, collapse = " - ")),
-    scenNames = scenNames,
-    name = outName,
-    savePlots = savePlots
+    scenNames = scenNames
   )
 
   # All output will be stored in the first directory passed

--- a/R/reportCalibration.R
+++ b/R/reportCalibration.R
@@ -87,13 +87,11 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
     diagDevFiles[varFlow]
   )
 
-  diagValNames <- c(
-    list(
-      stepSize = "stepSize",
-      outerObjective = "f",
-      lapply(stats::setNames(nm = varFlow), function(nm) "d")
-    )
+  diagValNames <- list(
+    stepSize = "stepSize",
+    outerObjective = "f"
   )
+  diagValNames[varFlow] <- "d"
 
   diagnosticsExist <- all(file.exists(file.path(path, diagFiles)))
   if (diagnosticsExist) {
@@ -207,23 +205,22 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
 
     diagnostics <- c(
       diagnostics[c("stepSize", "outerObjective")],
-      stats::setNames(
-        lapply(varFlowHs, function(var) {
-          .computeAvg(diagnostics[[var]], rprt = c("iteration", "region", "typ", "loc", "inc", "hsr", "ttot"),
-                      valueName = "d",
-                      exclude = list(hs = "h2bo", hsr = "h2bo"))
-        }), paste0(namingMap[varFlowHs], "DescDirHs")
-      )
+      lapply(stats::setNames(varFlowHs, paste0(namingMap[varFlowHs], "DescDirHs")), function(var) {
+        .computeAvg(diagnostics[[var]],
+                    rprt = c("iteration", "region", "typ", "loc", "inc", "hsr", "ttot"),
+                    exclude = list(hs = "h2bo", hsr = "h2bo"))
+      })
     )
 
     # Direction of steepest descent by heating system for late iterations
     diagnostics <- c(
       diagnostics,
-      stats::setNames(
-        lapply(paste0(namingMap[varFlowHs], "DescDirHs"), function(var) {
+      lapply(
+        stats::setNames(paste0(namingMap[varFlowHs], "DescDirHs"), paste0(namingMap[varFlowHs], "DescDirHsLate")),
+        function(var) {
           diagnostics[[var]] %>%
             filter(.data[["iteration"]] >= floor(0.4 * maxIter))
-        }), paste0(namingMap[varFlowHs], "DescDirHsLate")
+        }
       )
     )
 
@@ -233,20 +230,20 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   # Specific costs
   out <- c(
     out,
-    stats::setNames(lapply(varFlowBs, function(var) {
+    lapply(stats::setNames(varFlowBs, paste0(namingMap[varFlowBs], "SpecCostBs")), function(var) {
       .computeAvg(
         p_intangCost[[var]],
         rprt = c("iteration", "region", "typ", "loc", "inc", "bsr", "ttot"),
         exclude = list(hs = "h2bo", hsr = "h2bo")
       )
-    }), paste0(namingMap[varFlowBs], "SpecCostBs")),
-    stats::setNames(lapply(varFlowHs, function(var) {
+    }),
+    lapply(stats::setNames(varFlowHs, paste0(namingMap[varFlowHs], "SpecCostHs")), function(var) {
       .computeAvg(
         p_intangCost[[var]],
         rprt = c("iteration", "region", "typ", "loc", "inc", "hsr", "ttot"),
         exclude = list(hs = "h2bo", hsr = "h2bo")
       )
-    }), paste0(namingMap[varFlowHs], "SpecCostHs"))
+    })
   )
 
   # Aggregated brick results by heating system (hs)
@@ -268,9 +265,9 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   if (isFALSE(aggVin)) {
     out <- c(
       out,
-      stats::setNames(lapply(varAllVin, function(var) {
+      lapply(stats::setNames(varAllVin, paste0(namingMap[varAllVin], "Vin")), function(var) {
         .computeSum(brickRes[[var]], rprt = c("iteration", "region", "typ", "loc", "inc", "vin", "ttot"))
-      }), paste0(namingMap[varAllVin], "Vin"))
+      })
     )
   }
 
@@ -321,9 +318,9 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   # Across all dimensions
   out <- c(
     out,
-    stats::setNames(lapply(varAll, function(var) {
+    lapply(stats::setNames(varAll, paste0(namingMap[varAll], "DevRel")), function(var) {
       .computeRelDev(devAgg[[var]], p_calibTarget[[var]], tCalib)
-    }), paste0(namingMap[varAll], "DevRel")),
+    }),
     list(flowDevRel = .computeRelDev(out[["flowDevAgg"]], p_calibTarget[varFlow],
                                      tCalib))
   )
@@ -331,9 +328,9 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   # Separately for all heating systems (hs)
   out <- c(
     out,
-    stats::setNames(lapply(varAllHs, function(var) {
+    lapply(stats::setNames(varAllHs, paste0(namingMap[varAllHs], "DevHsRel")), function(var) {
       .computeRelDev(devHs[[var]], p_calibTarget[[var]], tCalib, notInTargetGrp = "hsr")
-    }), paste0(namingMap[varAllHs], "DevHsRel")),
+    }),
     list(flowDevHsRel = .computeRelDev(
       out[["flowDevHs"]],
       p_calibTarget[varFlowHs],
@@ -345,9 +342,9 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   # Deviation share for all heating systems (hs)
   out <- c(
     out,
-    stats::setNames(lapply(varAllHs, function(var) {
+    lapply(stats::setNames(varAllHs, paste0(namingMap[varAllHs], "DevHsShare")), function(var) {
       .computeRatioSq(devHs[[var]], devAgg[[var]])
-    }), paste0(namingMap[varAllHs], "DevHsShare")),
+    }),
     list(flowDevHsShare = .computeRatioSq(out[["flowDevHs"]], out[["flowDevAgg"]]))
   )
 
@@ -355,9 +352,9 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   if (isFALSE(aggVin)) {
     out <- c(
       out,
-      stats::setNames(lapply(varAllVin, function(var) {
+      lapply(stats::setNames(varAllVin, paste0(namingMap[varAllVin], "DevVinRel")), function(var) {
         .computeRelDev(devVin[[var]], p_calibTarget[[var]], tCalib, notInTargetGrp = "vin")
-      }), paste0(namingMap[varAllVin], "DevVinRel"))
+      })
     )
   }
 
@@ -386,6 +383,7 @@ reportCalibration <- function(gdx, flowTargets = TRUE) {
   write.csv(out, file.path(path, outName), row.names = FALSE)
 
 }
+
 
 
 #' Get dimension names from stock and flow objects

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reportbrick: Reporting package for BRICK - Version 0.12.0},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-09-03},
+  date = {2025-09-17},
   year = {2025},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for BRICK
 
-R package **reportbrick**, version **0.11.0**
+R package **reportbrick**, version **0.12.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reportbrick)](https://cran.r-project.org/package=reportbrick) [![R build status](https://github.com/pik-piam/reportbrick/workflows/check/badge.svg)](https://github.com/pik-piam/reportbrick/actions) [![codecov](https://codecov.io/gh/pik-piam/reportbrick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reportbrick) [![r-universe](https://pik-piam.r-universe.dev/badges/reportbrick)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,17 +38,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **reportbrick** in publications use:
 
-Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.11.0, <https://github.com/pik-piam/reportbrick>.
+Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK - Version 0.12.0."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {reportbrick: Reporting package for BRICK},
+  title = {reportbrick: Reporting package for BRICK - Version 0.12.0},
   author = {Robin Hasse and Ricarda Rosemann},
   date = {2025-09-03},
   year = {2025},
-  url = {https://github.com/pik-piam/reportbrick},
-  note = {Version: 0.11.0},
 }
 ```

--- a/inst/plotsCalibrationReporting/plotsCalibration.Rmd
+++ b/inst/plotsCalibrationReporting/plotsCalibration.Rmd
@@ -12,7 +12,6 @@ params:
     cal: "BRICK_calibration_report.csv"
     path: ""
     scenNames: NULL
-    savePlots: false
     name: ""
     figWidth: 15 
     figHeight: 10
@@ -37,7 +36,7 @@ knitr::opts_chunk$set(
 ```
 
 
-```{r set variables and functions, check existence of first file}
+```{r set variables and check existence of first file}
 
 # Assemble all file paths
 filePath <- file.path(params$path, params$cal)
@@ -54,18 +53,72 @@ if (!is.null(params$scenNames)) {
   names(filePath) <- params$scenNames
 }
 
-savePlots <- params$savePlots
-outName <- params$name
 outPath <- dirname(filePath[1])
 
 customPlots <- params$customPlots
 extendedPlots <- params$extendedPlots
+```
+
+
+```{r load data}
+
+if (length(filePath) == 1) {
+  data <- utils::read.csv(filePath)
+  color <- "ttot"
+  facets <- c("loc", "typ")
+} else if (length(filePath) > 1) {
+  # If more than one file path is given: Assemble all data in one data frame
+  data <- data.frame()
+  maxIter <- Inf
+  for (scen in names(filePath)) {
+    if (file.exists(filePath[[scen]])) {
+      tmp <- utils::read.csv(filePath[[scen]]) %>%
+        mutate(scenario = scen, .before = 1)
+      maxIter <- min(max(tmp[["iteration"]]), maxIter) # Find maximum common iteration
+      data <- rbind(data, tmp)
+    } else {
+      warning("The file", filePath[[scen]], "does not exist and was skipped.")
+    }
+  }
+  # Filter for common iterations (TODO: maybe add a switch to suppress this)
+  data <- filter(data, .data[["iteration"]] <= maxIter)
+  color <- "scenario"
+  facets <- "scenario"
+}
+
+# Determine whether this is sequential or hierarchical calibration
+varAll <- NULL
+if (all(c("renBSDevAgg", "renHSDevAgg") %in% data$variable)) {
+  varAll <- c("stock", "construction", "renovationBS", "renovationHS", "flow")
+} else {
+  varAll <- c("stock", "construction", "renovation", "flow")
+}
+
+namingMap <- c(
+  stock = "stock",
+  construction = "con",
+  renovation = "ren",
+  renovationBS = "renBS",
+  renovationHS = "renHS",
+  flow = "flow"
+)
+
+```
+
+
+```{r define functions}
+
+# Helper: generate varNames for calibration plots
+.getVarNames <- function(suffix, skipVars = NULL) {
+  vars <- setdiff(varAll, skipVars)
+  paste0(namingMap[vars], suffix)
+}
 
 # Standard procedure to write a calibration plot
-.createCalibrationPlot <- function(data, varName, outPath, outName = "",
+.createCalibrationPlot <- function(data, varName, outPath,
                                    color = NULL, facets = c("loc", "typ"),
-                                   yToZero = TRUE, savePlots = FALSE,
-                                   keepCol = NULL, addColor = NULL, newColors = NULL,
+                                   yToZero = TRUE, keepCol = NULL,
+                                   addColor = NULL, newColors = NULL,
                                    textSize = 20) {
   # Extract the data
   plData <- data %>%
@@ -108,43 +161,19 @@ extendedPlots <- params$extendedPlots
       pl <- pl + ggplot2::scale_colour_manual(values = c(mip::plotstyle(colorMap, unknown = newColors)))
     }
     pl <- pl + ggplot2::theme(text = ggplot2::element_text(size = textSize))
-    # Currently, this overwrites previous plots so that only the last one remains
-    if (isTRUE(savePlots)) {
-      ggplot2::ggsave(file.path(outPath, paste0(paste(varName, outName, sep = "_"), ".png")), pl)
-    }
     print(pl)
   })
 }
 
-
-```
-
-
-```{r load data}
-
-if (length(filePath) == 1) {
-  data <- utils::read.csv(filePath)
-  color <- "ttot"
-  facets <- c("loc", "typ")
-} else if (length(filePath) > 1) {
-  # If more than one file path is given: Assemble all data in one data frame
-  data <- data.frame()
-  maxIter <- Inf
-  for (scen in names(filePath)) {
-    if (file.exists(filePath[[scen]])) {
-      tmp <- utils::read.csv(filePath[[scen]]) %>%
-        mutate(scenario = scen, .before = 1)
-      maxIter <- min(max(tmp[["iteration"]]), maxIter) # Find maximum common iteration
-      data <- rbind(data, tmp)
-    } else {
-      warning("The file", filePath[[scen]], "does not exist and was skipped.")
-    }
+# Helper: run calibration plots for a given suffix
+.runCalibrationPlots <- function(suffix, color, facets = c("loc", "typ"), skipVars = NULL) {
+  varNames <- .getVarNames(suffix, skipVars)
+  for (var in varNames) {
+    .createCalibrationPlot(data, var, outPath,
+                           color = color, facets = facets)
   }
-  # Filter for common iterations (TODO: maybe add a switch to suppress this)
-  data <- filter(data, .data[["iteration"]] <= maxIter)
-  color <- "scenario"
-  facets <- "scenario"
 }
+
 
 ```
 
@@ -153,7 +182,8 @@ if (length(filePath) == 1) {
 
 ```{r}
 varReference <- read.csv(getSystemFile(file.path("plotsCalibrationReporting", "variableNames.csv"),
-                                       package = "reportbrick"))
+                                       package = "reportbrick")) %>%
+  filter(.data$variable %in% data$variable)
 
 varReference %>%
   kableExtra::kbl(
@@ -179,27 +209,27 @@ dataRelQuant <- data %>%
   filter(is.na(.data$ttot) | .data$ttot == ttotFirst) %>%
   mutate(ttot = NA)
 
+renHsVar <- grep("renovation$|HS$", varAll, value = TRUE)
+
+overviewAbsolute <- c("outerObjective", "stepSize", "stockDevHs", "conDevHs", "flowDevHs",
+                      paste0(namingMap[renHsVar], c("DescDirHs", "SpecCostHs", "DevAgg", "DevHs")))
+
+overviewRelative <- c("outerObjective", "stepSize", "stockDevHsRel", "conDevHsRel", "flowDevHsRel",
+                      paste0(namingMap[renHsVar], c("DescDirHs", "SpecCostHs", "DevRel", "DevHsRel")))
+
 .createCalibrationPlot(
   dataRelQuant,
-  c("descDirRen", "flowDevAgg", "flowDevHs", "conDevHs", "specCostRen", "outerObjective",
-    "renDevHs", "stepSize", "stockDevHs"),
+  overviewAbsolute,
   outPath,
-  outName = outName,
   color = "hsr",
-  facets = "variable",
-  addColor = c(gabo_id = "Gas identical replacement"),
-  newColor = data.frame(row.names = "Gas identical replacement", color = "#8B8378")
+  facets = "variable"
 )
 .createCalibrationPlot(
   dataRelQuant,
-  c("descDirRen", "flowDevRel", "flowDevHsRel", "conDevHsRel", "specCostRen", "renDevHsRel",
-    "renDevDiffGasRel", "stepSize", "stockDevAgg", "stockDevHsRel"),
+  overviewRelative,
   outPath,
-  outName = outName,
   color = "hsr",
-  facets = "variable",
-  addColor = c(gabo_id = "Gas identical replacement"),
-  newColor = data.frame(row.names = "Gas identical replacement", color = "#8B8378")
+  facets = "variable"
 )
 
 ```
@@ -211,17 +241,17 @@ dataRelQuant <- data %>%
 
 ```{r stock and flows by hs}
 
-.createCalibrationPlot(data, "stockHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.createCalibrationPlot(data, "stockHs", outPath,
+                       color = "hsr", facets = facets)
 
-.createCalibrationPlot(data, "conHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.createCalibrationPlot(data, "conHs", outPath,
+                       color = "hsr", facets = facets)
 
-.createCalibrationPlot(data, "renHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.createCalibrationPlot(data, "renHs", outPath,
+                       color = "hsr", facets = facets)
 
-.createCalibrationPlot(data, "flowHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.createCalibrationPlot(data, "flowHs", outPath,
+                       color = "hsr", facets = facets)
 
 ```
 
@@ -229,12 +259,7 @@ dataRelQuant <- data %>%
 
 ```{r stock and flows by vin}
 
-if (all(c("stockVin", "renVin") %in% data$variable)) {
-  .createCalibrationPlot(data, "stockVin", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-  .createCalibrationPlot(data, "renVin", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-}
+.runCalibrationPlots("Vin", color = "vin", facets = facets, skipVars = c("construction", "flow"))
 
 ```
 
@@ -245,17 +270,8 @@ if (all(c("stockVin", "renVin") %in% data$variable)) {
 
 ```{r Total absolute stock and flow deviations}
 
-.createCalibrationPlot(data, "stockDevAgg", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
+.runCalibrationPlots("DevAgg", color)
 
-.createCalibrationPlot(data, "conDevAgg", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevAgg", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
-
-.createCalibrationPlot(data, "flowDevAgg", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
 
 ```
 
@@ -263,34 +279,16 @@ if (all(c("stockVin", "renVin") %in% data$variable)) {
 
 ```{r absolute stock and flow deviations by hs}
 
-.createCalibrationPlot(data, "stockDevHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "conDevHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "flowDevHs", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevSepGabo", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots,
-                       addColor = c(gabo_id = "Gas identical replacement"),
-                       newColor = data.frame(row.names = "Gas identical replacement", color = "#8B8378"))
+.runCalibrationPlots("DevHs", color = "hsr", facets = facets, skipVars = "renovationBS")
 
 ```
 
 ## Absolute deviations by vintage
 
 ```{r absolute stock and flow deviations by vin}
-if (all(c("stockDevVin", "renDevVin") %in% data$variable)) {
-  .createCalibrationPlot(data, "stockDevVin", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-  .createCalibrationPlot(data, "renDevVin", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-}
+
+.runCalibrationPlots("DevVin", color = "vin", facets = facets, skipVars = c("construction", "flow"))
+
 ```
 
 
@@ -300,17 +298,7 @@ if (all(c("stockDevVin", "renDevVin") %in% data$variable)) {
 
 ```{r total relative stock and flow deviations}
 
-.createCalibrationPlot(data, "stockDevRel", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
-
-.createCalibrationPlot(data, "conDevRel", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevRel", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
-
-.createCalibrationPlot(data, "flowDevRel", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
+.runCalibrationPlots("DevRel", color)
 
 ```
 
@@ -318,22 +306,7 @@ if (all(c("stockDevVin", "renDevVin") %in% data$variable)) {
 
 ```{r relative stock and flow deviation by hs}
 
-.createCalibrationPlot(data, "stockDevHsRel", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "conDevHsRel", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevHsRel", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "flowDevHsRel", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renDevSepGaboRel", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots,
-                       addColor = c(gabo_id = "Gas identical replacement"),
-                       newColor = data.frame(row.names = "Gas identical replacement", color = "#FAEBD7"))
+.runCalibrationPlots("DevHsRel", color = "hsr", facets = facets, skipVars = "renovationBS")
 
 ```
 
@@ -341,14 +314,7 @@ if (all(c("stockDevVin", "renDevVin") %in% data$variable)) {
 
 ```{r relative stock and flow deviation by hs, alternative 2}
 
-.createCalibrationPlot(data, "stockDevHsShare", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-.createCalibrationPlot(data, "conDevHsShare", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-.createCalibrationPlot(data, "renDevHsShare", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-.createCalibrationPlot(data, "flowDevHsShare", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.runCalibrationPlots("DevHsShare", color = "hsr", facets = facets, skipVars = "renovationBS")
 
 ```
 
@@ -356,12 +322,7 @@ if (all(c("stockDevVin", "renDevVin") %in% data$variable)) {
 
 ```{r relative stock and flow deviation by vin}
 
-if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
-  .createCalibrationPlot(data, "stockDevVinRel", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-  .createCalibrationPlot(data, "renDevVinRel", outPath, outName = outName,
-                         color = "vin", facets = facets, savePlots = savePlots)
-}
+.runCalibrationPlots("DevVinRel", color = "vin", facets = facets, skipVars = c("construction", "flow"))
 
 ```
 
@@ -372,14 +333,7 @@ if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
 
 ```{r aggregate stock and flow deviations}
 
-.createCalibrationPlot(data, "stockTotDev", outPath, outName = outName,
-                       color = color, facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "conTotDev", outPath, outName = outName,
-                       color = color, facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renTotDev", outPath, outName = outName,
-                       color = color, facets = facets, savePlots = savePlots)
+.runCalibrationPlots("TotDev", color = color, facets = facets, skipVars = "flow")
 
 ```
 
@@ -387,14 +341,7 @@ if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
 
 ```{r agg stock and flow deviations by hs}
 
-.createCalibrationPlot(data, "stockTotHsDev", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "conTotHsDev", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
-
-.createCalibrationPlot(data, "renTotHsDev", outPath, outName = outName,
-                       color = "hsr", facets = facets, savePlots = savePlots)
+.runCalibrationPlots("TotHsDev", color = "hsr", facets = facets, skipVars = c("renovationBS", "flow"))
 
 ```
 
@@ -404,8 +351,7 @@ if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
 
 ```{r outer objective}
 
-.createCalibrationPlot(data, "outerObjective", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
+.createCalibrationPlot(data, "outerObjective", outPath, color = color)
 
 ```
 
@@ -413,19 +359,24 @@ if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
 
 ```{r step size}
 
-.createCalibrationPlot(data, "stepSize", outPath, outName = outName,
-                       color = color, savePlots = savePlots)
+.createCalibrationPlot(data, "stepSize", outPath, color = color)
+```
+
+## Intangible costs by building shell
+
+```{r intangible costs by building shell}
+
+.runCalibrationPlots("SpecCostBs", color = "bsr", facets = facets,
+                     skipVars = c("stock", "renovationHS", "flow"))
+
 ```
 
 ## Intangible costs by heating system
 
 ```{r intangible costs by heating system}
 
-.createCalibrationPlot(data, "specCostCon", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
+.runCalibrationPlots("SpecCostHs", color = "hsr", facets = facets, skipVars = c("stock", "renovationBS", "flow"))
 
-.createCalibrationPlot(data, "specCostRen", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
 ```
 
 
@@ -433,15 +384,7 @@ if (all(c("stockDevVinRel", "renDevVinRel") %in% data$variable)) {
 
 ```{r descent direction by heating system}
 
-.createCalibrationPlot(data, "descDirCon", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
+.runCalibrationPlots("DescDirHs", color = "hsr", facets = facets, skipVars = c("stock", "renovationBS", "flow"))
 
-.createCalibrationPlot(data, "descDirRen", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
-
-.createCalibrationPlot(data, "descDirConLate", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
-
-.createCalibrationPlot(data, "descDirRenLate", outPath, outName = outName,
-                       color = "hsr", savePlots = savePlots)
+.runCalibrationPlots("DescDirHsLate", color = "hsr", facets = facets, skipVars = c("stock", "renovationBS", "flow"))
 ```

--- a/inst/plotsCalibrationReporting/variableNames.csv
+++ b/inst/plotsCalibrationReporting/variableNames.csv
@@ -1,41 +1,61 @@
 variable,description
 targetFunction,Target function of the optimization
 stepSize,Step size of the optimization
-intangCostConHs,Intangible costs of construction by heating system
-intangCostRenHs,Intangible costs of renovation by heating system
-descDirConHs,Direction of the adjustment step in the optimization of intangible construction costs by heating system
-descDirRenHs,Direction of the adjustment step in the optimization of intangible renovation costs by heating system
-descDirConHsLate,"Direction of the adjustment step in the optimization of intangible construction costs by heating system; late iterations"
-descDirRenHsLate,"Direction of the adjustment step in the optimization of intangible renovation costs by heating system; late iterations"
+conSpecCostBs,Intangible costs of construction by building shell
+renSpecCostBs,Intangible costs of renovation by building shell
+renBSSpecCostBs,Intangible costs of renovation by building shell
+conSpecCostHs,Intangible costs of construction by heating system
+renSpecCostHs,Intangible costs of renovation by heating system
+renHSSpecCostHs,Intangible costs of renovation by heating system
+conDescDirHs,Direction of the adjustment step in the optimization of intangible construction costs by heating system
+renDescDirHs,Direction of the adjustment step in the optimization of intangible renovation costs by heating system
+renHSDescDirHs,Direction of the adjustment step in the optimization of intangible renovation costs by heating system
+conDescDirHsLate,Direction of the adjustment step in the optimization of intangible construction costs by heating system; late iterations
+renDescDirHsLate,Direction of the adjustment step in the optimization of intangible renovation costs by heating system; late iterations
+renHSDescDirHsLate,Direction of the adjustment step in the optimization of intangible renovation costs by heating system; late iterations
 stockHs,Stock by heating system
 conHs,Construction by heating system
 renHs,Renovation by heating system
 flowHs,All flows (i.e. construction and renovation) by heating system
 stockVin,Stock by vintage
 renVin,Renovation by vintage
+renBSVin,Shell renovation by vintage
+renHSVin,Heating renovation by vintage
 stockDevAgg,Total Deviation of the stock from historic values
 conDevAgg,Total Deviation of construction from historic values
 renDevAgg,Total Deviation of renovation from historic values
+renBSDevAgg,Total Deviation of shell renovation from historic values
+renHSDevAgg,Total Deviation of heating renovation from historic values
 flowDevAgg,Total Deviation of all flows from historic values
 stockDevHs,Deviation of the stock by heating system
 conDevHs,Deviation of construction by heating system
 renDevHs,Deviation of renovation by heating system
+renHSDevHs,Deviation of heating renovation by heating system
 flowDevHs,Deviation of all flows by heating system
 renDevSepGabo,Deviation of renovation by heating system with identical replacement of gas boilers viewed separately
 stockDevVin,Deviation of the stock by vintage
 renDevVin,Deviation of renovations by vintage
+renBSDevVin,Deviation of shell renovations by vintage
+renHSDevVin,Deviation of heating renovations by vintage
 stockDevRel,Total Deviation of the stock relative to total historical stock
 conDevRel,Total Deviation of construction relative to total historical construction
 renDevRel,Total Deviation of renovation relative to historical renovations
+renBSDevRel,Total Deviation of shell renovation relative to historical renovations
+renHSDevRel,Total Deviation of heating renovation relative to historical renovations
 flowDevRel,Total Deviation of all flows relative to historical flows
 stockDevHsRel,Relative Deviation of the stock by heating system
 conDevHsRel,Relative Deviation of construction by heating system
 renDevHsRel,Relative Deviation of renovation by heating system
+renBSDevHsRel,Relative Deviation of shell renovation by heating system
+renHSDevHsRel,Relative Deviation of heating renovation by heating system
 flowDevHsRel,Relative Deviation of all flows by heating system
 renDevSepGaboRel,Relative Deviation of renovation by heating system with identical replacement of gas boilers viewed separately
 stockDevHsShare,Share of the total stock deviation by heating system
 conDevHsShare,Share of the total construction deviation by heating system
 renDevHsShare,Share of the total renovation deviation by heating system
+renHSDevHsShare,Share of the total heating renovation deviation by heating system
 flowDevHsShare,Share of the total flow deviation by heating system
 stockDevVinRel,Relative Deviation of the stock by vintage
 renDevVinRel,Relative Deviation of renovations by vintage
+renBSDevVinRel,Relative Deviation of shell renovations by vintage
+renHSDevVinRel,Relative Deviation of heating renovations by vintage

--- a/man/dot-computeAvg.Rd
+++ b/man/dot-computeAvg.Rd
@@ -4,12 +4,14 @@
 \alias{.computeAvg}
 \title{Compute the mean value in a data frame}
 \usage{
-.computeAvg(df, rprt = "", exclude = list())
+.computeAvg(df, rprt = "", valueName = "value", exclude = list())
 }
 \arguments{
 \item{df}{data frame, containing the data to be evaluated}
 
 \item{rprt}{character, column names for which the mean should be reported separately}
+
+\item{valueName}{character, name of the column containing the values to be manipulated}
 
 \item{exclude}{named list with entries to be excluded from the data.
 The name gives the column name from which the entries given by the value should

--- a/man/dot-computeFlowSum.Rd
+++ b/man/dot-computeFlowSum.Rd
@@ -4,12 +4,12 @@
 \alias{.computeFlowSum}
 \title{Compute the sum of construction and renovation flow values}
 \usage{
-.computeFlowSum(con, ren)
+.computeFlowSum(flows)
 }
 \arguments{
-\item{con}{data frame, contains construction flow quantities}
-
-\item{ren}{data frame, contains renovation flow quantities}
+\item{flows}{named list of data frames, each containing flow quantities.
+Entries need to include \code{construction}
+and one entry with \code{renovation} as part of the name.}
 }
 \value{
 data frame with the sum in the value column

--- a/man/plotBRICKCalib.Rd
+++ b/man/plotBRICKCalib.Rd
@@ -8,8 +8,7 @@ plotBRICKCalib(
   path = ".",
   cal = "BRICK_calibration_report.csv",
   outName = "",
-  scenNames = NULL,
-  savePlots = FALSE
+  scenNames = NULL
 )
 }
 \arguments{
@@ -22,8 +21,6 @@ If several paths are given, the names can be used to pass short scenario names.}
 
 \item{scenNames}{character vector, scenario names for different paths.
 Needs to be specified if \code{path} is unnamed and contains more than one element.}
-
-\item{savePlots}{logical, whether all plots should additionally be saved as png}
 }
 \description{
 Renders the file plotCalibration.Rmd to create the plots for the BRICK calibration


### PR DESCRIPTION
## Purpose of this PR
Enable the calibration reporting for the brick implementation with the options of sequential and hierarchical implementation.

## Code changes

### To adapt to sequential renovation
- Rewrite ```reportCalibration``` so that it can handle both ```v_renovation``` and ```v_renovationBS``` + ```v_renovationHS``` as relevant Gams variable.
- In the course of this, vectorise along all variables considered.
- The code now always expects calibration targets for stock, construction and renovation; this behavior can no longer be switched off.
- Change order in plotting Rmd (necessary so that all variables are defined when they are needed).
- Use additional helper functions in the plotting Rmd.

### Additional changes
- Remove separate reporting of identical replacement for gabo and the corresponding plots.
- Remove the option to save plots as png (because these would be too numerous).