### PR TITLE
Fix bug in renovation reporting with ignoreShell

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2462108'
+ValidationKey: '2462713'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'reportbrick: Reporting package for BRICK'
 version: 0.12.1
-date-released: '2025-09-17'
+date-released: '2025-09-22'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
 Version: 0.12.1
-Date: 2025-09-17
+Date: 2025-09-22
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/reportRenovation.R
+++ b/R/reportRenovation.R
@@ -193,12 +193,10 @@ reportRenovation <- function(gdx, renovatedObj = c("bs", "hs"),
         " (bn m2/yr)"
       )
       if (all(c(renFinal, renIdentRepl) %in% getItems(out, dim = 3))) {
-        outChangeFinal <- setNames(out[, , renFinal, drop = TRUE] - out[, , renIdentRepl, drop = TRUE],
-                                   renChangeFinal)
+        setNames(out[, , renFinal, drop = TRUE] - out[, , renIdentRepl, drop = TRUE], renChangeFinal)
       } else {
-        outChangeFinal <- NULL
+        NULL
       }
-      outChangeFinal
     }))
   )
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reportbrick: Reporting package for BRICK - Version 0.12.1},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-09-17},
+  date = {2025-09-22},
   year = {2025},
 }
 ```


### PR DESCRIPTION
```convGDX2MIF``` did not work with ignoreShell because ```reportRenovation``` was trying to access some variables that do not exist in that case. This PR fixes the issue.