### PR TITLE
Use ref-specific colors in matching comparison

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2656030'
+ValidationKey: '2861460'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reportbrick: Reporting package for BRICK'
-version: 0.13.0
-date-released: '2025-12-09'
+version: 0.14.0
+date-released: '2025-12-17'
 abstract: This package contains BRICK-specific routines to report model results. The
   main functionality is to generate a mif-file from a given BRICK model run folder.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
   knitr,
   madrat,
   magclass,
-  mip (>= 0.148.19),
+  mip (>= 0.155.6),
   piamPlotComparison,
   piamutils (>= 0.0.9),
   purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reportbrick
 Title: Reporting package for BRICK
-Version: 0.13.0
-Date: 2025-12-09
+Version: 0.14.0
+Date: 2025-12-17
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/readGdxSymbol.R
+++ b/R/readGdxSymbol.R
@@ -67,6 +67,8 @@ readGdxSymbol <- function(gdx, symbol, field = "level", asMagpie = NULL,
       if (isTRUE(removeDescription)) {
         data <- data %>%
           select(-"element_text")
+      } else {
+        data$element_text[data$element_text == "NA"] <- NA
       }
       if (isTRUE(asMagpie)) {
         warning("Sets are not reported as Magpie object.")

--- a/R/showMatchingComparison.R
+++ b/R/showMatchingComparison.R
@@ -18,6 +18,25 @@
 
 showMatchingComparison <- function(path, showTitles = TRUE) {
 
+  .getColors <- function(refVars, refVarGroups) {
+
+    .descr2Color <- function(description, refVar) {
+      isColor <- !is.na(description) & grepl("^hex:", description)
+      x <- rep(NA, length(description))
+      x[isColor] <- sub("^hex:", "#", description[isColor])
+      x[!isColor] <- mip::plotstyle(ifelse(is.na(description[!isColor]) | description[!isColor] == "",
+                                           refVar[!isColor],
+                                           description[!isColor]))
+      x
+    }
+    refVars %>%
+      left_join(refVarGroups, by = c("reference", "refVar")) %>%
+      group_by(across(all_of(c("reference", "refVarGroup")))) %>%
+      mutate(color = .descr2Color(.data$element_text, .data$refVar)) %>%
+      ungroup() %>%
+      select(-"element_text", -"refVarGroup")
+  }
+
   .combineModelAndTargetData <- function(p_refVals, v_refVals, valTypes) {
     right_join(p_refVals, v_refVals,
                by = c("reference", "refVar", "region", ttot = "t"),
@@ -27,6 +46,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
 
   .addConsiderationCol <- function(x, refVarConsidered) {
     refVarConsidered %>%
+      select("reference", "refVar") %>%
       mutate(considered = TRUE) %>%
       right_join(x, by = c("reference", "refVar")) %>%
       replace_na(list(considered = FALSE)) %>%
@@ -69,7 +89,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
   }
 
 
-  .plot <- function(pData, yLabel = NULL) {
+  .plot <- function(pData, colors, yLabel = NULL) {
     ggplot(pData) +
       geom_hline(yintercept = 0) +
       suppressWarnings(geom_col(aes(x = .data$x,
@@ -82,7 +102,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
       facet_grid(region ~ ., scales = "free_y") +
       scale_x_continuous(NULL, expand = c(0, 0)) +
       scale_y_continuous(yLabel, expand = c(0, 0)) +
-      scale_fill_brewer(palette = "Set1") +
+      scale_fill_manual(values = colors) +
       scale_linetype_manual(values = c(model = "solid", target = "dashed")) +
       scale_alpha_manual(values = c(`TRUE` = 1, `FALSE` = 0.4), guide = "none") +
       scale_color_manual(values = c(`TRUE` = "black", `FALSE` = "darkgrey"), guide = "none") +
@@ -109,6 +129,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
   refsRel <- readGdxSymbol(gdx, "refRel", stringAsFactor = FALSE)[[1]]
   refVarBasic <- readGdxSymbol(gdx, "refVarBasic")
   refVarConsidered <- readGdxSymbol(gdx, "refVarConsidered")
+  refVarRef <- readGdxSymbol(gdx, "refVarRef", removeDescription = FALSE)
 
 
 
@@ -116,6 +137,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
 
   description <- dplyr::pull(refs, var = "element_text", name = "reference")
   refs <- refs$reference
+  refVarColors <- .getColors(refVarRef, refVarBasic)
 
   refsWithWeight <- p_refWeight %>%
     filter(.data$value > 0) %>%
@@ -148,6 +170,10 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
       return(NULL)
     }
 
+    colors <- refVarColors %>%
+      filter(.data$reference == ref) %>%
+      pull("color", "refVar")
+
     if (ref %in% refsRel) {
       refVarGroups <- unique(pData$refVarGroup)
 
@@ -162,7 +188,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
       p <- lapply(setNames(nm = refVarGroups), function(rvg) {
         pRvg <- pData %>%
           filter(.data$refVarGroup == rvg) %>%
-          .plot(yLabel)
+          .plot(colors, yLabel)
         if (showTitles) {
           pRvg <- pRvg + ggtitle(ref, rvg)
         }
@@ -171,7 +197,7 @@ showMatchingComparison <- function(path, showTitles = TRUE) {
 
     } else {
 
-      p <- .plot(pData, yLabel)
+      p <- .plot(pData, colors, yLabel)
 
       if (showTitles) {
         p <- p + ggtitle(ref)

--- a/R/showSankey.R
+++ b/R/showSankey.R
@@ -80,11 +80,8 @@ showSankey <- function(path, # nolint: cyclocomp_linter.
   barsWithOutline <- c("Stock", "Construction", "Demolition_end")
 
   # colors that are not related to the fill dimension
-  colors <- list(
-    construction = "#7CAEAF",
-    demolition   = "#D26868",
-    untouched    = "#f1daab"
-  )
+  colors <- setNames(as.list(plotstyle(c("Construction", "Demolition", "Renovation"))),
+                     c("construction", "demolition", "untouched"))
 
   # transparency of untouched and identical replacement flows
   alphaSemiTransparent <- 0.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for BRICK
 
-R package **reportbrick**, version **0.13.0**
+R package **reportbrick**, version **0.14.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reportbrick)](https://cran.r-project.org/package=reportbrick) [![R build status](https://github.com/pik-piam/reportbrick/workflows/check/badge.svg)](https://github.com/pik-piam/reportbrick/actions) [![codecov](https://codecov.io/gh/pik-piam/reportbrick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reportbrick) [![r-universe](https://pik-piam.r-universe.dev/badges/reportbrick)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **reportbrick** in publications use:
 
-Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.13.0, <https://github.com/pik-piam/reportbrick>.
+Hasse R, Rosemann R (2025). "reportbrick: Reporting package for BRICK." Version: 0.14.0, <https://github.com/pik-piam/reportbrick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,9 +46,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reportbrick: Reporting package for BRICK},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-12-09},
+  date = {2025-12-17},
   year = {2025},
   url = {https://github.com/pik-piam/reportbrick},
-  note = {Version: 0.13.0},
+  note = {Version: 0.14.0},
 }
 ```


### PR DESCRIPTION
- Reference variables in the **matching comparison plot** can now be shown with **variable-specific colors** instead of generic Set3 colors.
  - Familiar colors help drastically interpretating the plots. Regular users will rarely need the legend anymore.
  - Colors are defined in the refMaps in `mredgebuildings`: pik-piam/mredgebuildins#87
  - `BRICK` writes these colors into set descriptions that can be read during reporting: pik-piam/brick#122
  - This update is backwards compatible. RefVars without color description (all in old runs) get default mip color (instead of Set3 colors before).
- minor change to **load flow colors for sankey plots from mip** instead of hard-coded colors
  - requires pik-piam/mip#141

<img width="1360" height="776" alt="grafik" src="https://github.com/user-attachments/assets/836117e6-9667-4c3e-af99-5805fd5a4b9a" />
